### PR TITLE
fixing update_config issue

### DIFF
--- a/lib/rtasklib/controller.rb
+++ b/lib/rtasklib/controller.rb
@@ -369,11 +369,11 @@ module Rtasklib
                    default: nil, urgency: nil
       label = name if label.nil?
 
-      update_config("uda.#{name}.type",  type)
-      update_config("uda.#{name}.label", label)
-      update_config("uda.#{name}.values",  values)  unless values.nil?
-      update_config("uda.#{name}.default", default) unless default.nil?
-      update_config("uda.#{name}.urgency", urgency) unless urgency.nil?
+      update_config!("uda.#{name}.type",  type)
+      update_config!("uda.#{name}.label", label)
+      update_config!("uda.#{name}.values",  values)  unless values.nil?
+      update_config!("uda.#{name}.default", default) unless default.nil?
+      update_config!("uda.#{name}.urgency", urgency) unless urgency.nil?
     end
 
     # Sync the local TaskWarrior database changes to the remote databases.


### PR DESCRIPTION
`create_uda!` was trying to use `update_config` instead of `update_config!`. This PR just inserts the missing `!`